### PR TITLE
Add optional timeout with tests, fix UnknownError for timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.payfurl</groupId>
     <artifactId>payfurlsdk</artifactId>
-    <version>1.0.20230413</version>
+    <version>1.0.20230414</version>
     <packaging>jar</packaging>
 
     <name>PayFURL</name>

--- a/src/main/java/com/payfurl/payfurlsdk/Configuration.java
+++ b/src/main/java/com/payfurl/payfurlsdk/Configuration.java
@@ -12,7 +12,7 @@ public interface Configuration {
 
     String getUserAgentDetail();
 
-    long timeout();
+    long getTimeout();
 
     String getSecretKey();
 

--- a/src/main/java/com/payfurl/payfurlsdk/PayFurlClient.java
+++ b/src/main/java/com/payfurl/payfurlsdk/PayFurlClient.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public class PayFurlClient implements PayFurlClientSdk {
-    private static final long DEFAULT_CALLS_TIMEOUT_SECONDS = TimeUnit.SECONDS.toMillis(60);
+    private static final long DEFAULT_CALLS_TIMEOUT_MILLISECONDS = TimeUnit.SECONDS.toMillis(60);
     private static final String SDK_VERSION = "2022.0.1";
     private static final String LOCAL_URL = "https://localhost:5001";
     private static final String SANDBOX_URL = "https://sandbox-api.payfurl.com";
@@ -226,7 +226,7 @@ public class PayFurlClient implements PayFurlClientSdk {
                 return userConfigTimeout;
             }
 
-            return DEFAULT_CALLS_TIMEOUT_SECONDS;
+            return DEFAULT_CALLS_TIMEOUT_MILLISECONDS;
         }
     }
 }

--- a/src/main/java/com/payfurl/payfurlsdk/api/BaseApi.java
+++ b/src/main/java/com/payfurl/payfurlsdk/api/BaseApi.java
@@ -104,7 +104,7 @@ public class BaseApi {
             HttpResponse response = getClientInstance().execute(request);
 
             return getDataFrom(response, returnType);
-        } catch (InterruptedIOException socketTimeoutException) {
+        } catch (InterruptedIOException interruptedIOException) {
             throw new ApiException(ApiError.buildTimeoutError());
         } catch (IOException exception) {
             throw new ApiException(exception);

--- a/src/main/java/com/payfurl/payfurlsdk/api/BaseApi.java
+++ b/src/main/java/com/payfurl/payfurlsdk/api/BaseApi.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.Range;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.SocketTimeoutException;
 import java.util.Map;
 
@@ -103,7 +104,7 @@ public class BaseApi {
             HttpResponse response = getClientInstance().execute(request);
 
             return getDataFrom(response, returnType);
-        } catch (SocketTimeoutException socketTimeoutException) {
+        } catch (InterruptedIOException socketTimeoutException) {
             throw new ApiException(ApiError.buildTimeoutError());
         } catch (IOException exception) {
             throw new ApiException(exception);

--- a/src/main/java/com/payfurl/payfurlsdk/api/support/ApiException.java
+++ b/src/main/java/com/payfurl/payfurlsdk/api/support/ApiException.java
@@ -38,7 +38,7 @@ public class ApiException extends RuntimeException {
         this.gatewayMessage = null;
         this.code = UNKNOWN_ERROR;
         this.isRetryable = false;
-        this.type = String.format("https://docs.payfurl.com/errorcodes.html#%d", UNKNOWN_ERROR);
+        this.type = String.format("https://docs.payfurl.com/errorcodes.html#%d", UNKNOWN_ERROR.ordinal());
         this.httpCode = 500;
     }
 

--- a/src/main/java/com/payfurl/payfurlsdk/http/client/OkClient.java
+++ b/src/main/java/com/payfurl/payfurlsdk/http/client/OkClient.java
@@ -125,7 +125,6 @@ public class OkClient implements HttpClient {
                 .headers(requestHeaders.build())
                 .url(url)
                 .build();
-
     }
 
     private static RequestBody createRequestBodyFrom(HttpRequest httpRequest) {

--- a/src/main/java/com/payfurl/payfurlsdk/http/client/OkClient.java
+++ b/src/main/java/com/payfurl/payfurlsdk/http/client/OkClient.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 
 public class OkClient implements HttpClient {
     private static final Object SIMPLE_SYNC_OBJECT = new Object();
-    private static final int DEFAULT_CALL_TIMEOUT_SECONDS = 60;
     private static volatile OkHttpClient defaultOkHttpClient;
     private final Environment environment;
     private OkHttpClient client;
@@ -44,7 +43,7 @@ public class OkClient implements HttpClient {
 
         OkHttpClient okClientInstance = getDefaultOkHttpClient();
         if (okClientInstance != null) {
-            this.client = okClientInstance;
+            this.client = getConfiguredHttpClient(okClientInstance, httpClientConfiguration);
         }
     }
 
@@ -151,6 +150,15 @@ public class OkClient implements HttpClient {
         return requestHeaders;
     }
 
+    private OkHttpClient getConfiguredHttpClient(OkHttpClient okHttpClient, HttpClientConfiguration httpClientConfiguration) {
+        return okHttpClient.newBuilder()
+                .readTimeout(httpClientConfiguration.getTimeout(), TimeUnit.MILLISECONDS)
+                .writeTimeout(httpClientConfiguration.getTimeout(), TimeUnit.MILLISECONDS)
+                .connectTimeout(httpClientConfiguration.getTimeout(), TimeUnit.MILLISECONDS)
+                .callTimeout(httpClientConfiguration.getTimeout(), TimeUnit.MILLISECONDS)
+                .build();
+    }
+
     private OkHttpClient getDefaultOkHttpClient() {
         if (defaultOkHttpClient != null) {
             return defaultOkHttpClient;
@@ -168,10 +176,6 @@ public class OkClient implements HttpClient {
     private OkHttpClient initializeOkClient() {
         OkHttpClient.Builder okClientBuilder = new OkHttpClient.Builder()
                 .retryOnConnectionFailure(false)
-                .callTimeout(DEFAULT_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .connectTimeout(DEFAULT_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .readTimeout(DEFAULT_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .writeTimeout(DEFAULT_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .followSslRedirects(true);
 
         if (Environment.LOCAL == environment) {

--- a/src/main/java/com/payfurl/payfurlsdk/http/client/config/HttpClientConfiguration.java
+++ b/src/main/java/com/payfurl/payfurlsdk/http/client/config/HttpClientConfiguration.java
@@ -29,9 +29,17 @@ public class HttpClientConfiguration {
             return this;
         }
 
+        public long getTimeout() {
+            return timeout;
+        }
+
         public Builder environment(Environment environment) {
             this.environment = environment;
             return this;
+        }
+
+        public Environment getEnvironment() {
+            return environment;
         }
 
         public HttpClientConfiguration build() {

--- a/src/main/java/com/payfurl/payfurlsdk/models/ApiError.java
+++ b/src/main/java/com/payfurl/payfurlsdk/models/ApiError.java
@@ -94,8 +94,7 @@ public class ApiError {
                 '}';
     }
 
-    public static ApiError buildTimeoutError()
-    {
+    public static ApiError buildTimeoutError() {
         return new ApiError.Builder()
                 .withIsRetryable(true)
                 .withCode(ErrorCode.Timeout)

--- a/src/test/java/com/payfurl/payfurlsdk/PayFurlClientTest.java
+++ b/src/test/java/com/payfurl/payfurlsdk/PayFurlClientTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -70,5 +71,25 @@ class PayFurlClientTest {
     @DisplayName("Given PayFurlClient When getSecretKeyAuthHandler is called Then return one secret key auth handler")
     void testGetSecretKeyAuthHandler() {
         then(dummyProdConfiguredClient.getSecretKeyAuthHandler().getSecretKey()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom default client")
+    void testDefaultTimeoutConfiguration() {
+        PayFurlClient payFurlClient = new PayFurlClient.Builder()
+                .build();
+
+        then(payFurlClient.getTimeout()).isEqualTo(TimeUnit.SECONDS.toMillis(60));
+    }
+
+    @Test
+    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom timeout client")
+    void testCustomTimeoutConfiguration() {
+        long smallTimeoutMs = 40;
+        PayFurlClient payFurlClient = new PayFurlClient.Builder()
+                .withHttpClientConfiguration((config) -> config.timeout(smallTimeoutMs))
+                .build();
+
+        then(payFurlClient.getTimeout()).isEqualTo(smallTimeoutMs);
     }
 }

--- a/src/test/java/com/payfurl/payfurlsdk/PayFurlClientTest.java
+++ b/src/test/java/com/payfurl/payfurlsdk/PayFurlClientTest.java
@@ -1,16 +1,24 @@
 package com.payfurl.payfurlsdk;
 
+import com.payfurl.payfurlsdk.api.ChargeApi;
+import com.payfurl.payfurlsdk.api.support.ApiException;
+import com.payfurl.payfurlsdk.api.support.ErrorCode;
 import com.payfurl.payfurlsdk.http.client.config.Environment;
+import com.payfurl.payfurlsdk.models.ApiError;
+import com.payfurl.payfurlsdk.models.NewChargeCardLeastCost;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 
 class PayFurlClientTest {
@@ -71,25 +79,5 @@ class PayFurlClientTest {
     @DisplayName("Given PayFurlClient When getSecretKeyAuthHandler is called Then return one secret key auth handler")
     void testGetSecretKeyAuthHandler() {
         then(dummyProdConfiguredClient.getSecretKeyAuthHandler().getSecretKey()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom default client")
-    void testDefaultTimeoutConfiguration() {
-        PayFurlClient payFurlClient = new PayFurlClient.Builder()
-                .build();
-
-        then(payFurlClient.getTimeout()).isEqualTo(TimeUnit.SECONDS.toMillis(60));
-    }
-
-    @Test
-    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom timeout client")
-    void testCustomTimeoutConfiguration() {
-        long smallTimeoutMs = 40;
-        PayFurlClient payFurlClient = new PayFurlClient.Builder()
-                .withHttpClientConfiguration((config) -> config.timeout(smallTimeoutMs))
-                .build();
-
-        then(payFurlClient.getTimeout()).isEqualTo(smallTimeoutMs);
     }
 }

--- a/src/test/java/com/payfurl/payfurlsdk/TimeoutTest.java
+++ b/src/test/java/com/payfurl/payfurlsdk/TimeoutTest.java
@@ -74,7 +74,7 @@ public class TimeoutTest {
     }
 
     @Test
-    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom timeout")
+    @DisplayName("Given PayFurlClient configuration with timeout When create OkHttClient is called Then return custom timeout")
     void testCustomTimeoutConfiguration() {
         long smallTimeoutMs = 40;
         PayFurlClient payFurlClient = new PayFurlClient.Builder()
@@ -88,7 +88,7 @@ public class TimeoutTest {
     class FailFlow {
 
         @Test
-        @DisplayName("Given PayFurlClient configuration with small timeout When create API is called Then throw client's timeout error")
+        @DisplayName("Given PayFurlClient configuration with small timeout When charge API is called Then throw client's timeout error")
         void testSmallTimeoutConfigurationToCauseException() {
             // given
             PayFurlClient lowTimeoutPayFurlClient = new PayFurlClient.Builder()

--- a/src/test/java/com/payfurl/payfurlsdk/TimeoutTest.java
+++ b/src/test/java/com/payfurl/payfurlsdk/TimeoutTest.java
@@ -1,0 +1,119 @@
+package com.payfurl.payfurlsdk;
+
+import com.google.common.collect.ImmutableMap;
+import com.payfurl.payfurlsdk.api.ChargeApi;
+import com.payfurl.payfurlsdk.api.support.ApiException;
+import com.payfurl.payfurlsdk.api.support.ErrorCode;
+import com.payfurl.payfurlsdk.models.Address;
+import com.payfurl.payfurlsdk.models.ApiError;
+import com.payfurl.payfurlsdk.models.CardRequestInformation;
+import com.payfurl.payfurlsdk.models.NewChargeCardLeastCost;
+import com.payfurl.payfurlsdk.models.Order;
+import com.payfurl.payfurlsdk.models.ProductItem;
+import com.payfurl.payfurlsdk.models.TransactionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+
+public class TimeoutTest {
+    private static final ImmutableMap<String, String> METADATA = ImmutableMap.of("merchant_id", "1234356");
+    private static final CardRequestInformation SAMPLE_PAYMENT_INFORMATION = new CardRequestInformation.Builder()
+            .withCardNumber("4111111111111111")
+            .withExpiryDate("12/35")
+            .withCcv("123")
+            .build();
+
+    private static final Address SAMPLE_ADDRESS = new Address.Builder()
+            .withLine1("91  Gloucester Avenue")
+            .withLine2("Apartment 2")
+            .withCity("Melbourne")
+            .withSate("Victoria")
+            .withPostalCode("5006")
+            .withCountry("Australia")
+            .build();
+
+    private static final List<ProductItem> ITEMS = Arrays.asList(new ProductItem.Builder()
+                    .withAmount(BigDecimal.valueOf(123))
+                    .withDescription("First item")
+                    .withQuantity(1)
+                    .withCommodityCode("asdf")
+                    .withProductCode("PC1234")
+                    .withUnitOfMeasure("kg")
+                    .build(),
+            new ProductItem.Builder()
+                    .withAmount(BigDecimal.valueOf(33))
+                    .withDescription("Second item")
+                    .withQuantity(4)
+                    .withCommodityCode("uuuu")
+                    .withProductCode("PC15678")
+                    .withUnitOfMeasure("kg")
+                    .build());
+
+    private static final Order SAMPLE_ORDER = new Order.Builder()
+            .withOrderNumber("12345ON")
+            .withDutyAmount(BigDecimal.valueOf(1))
+            .withFreightAmount(BigDecimal.valueOf(2))
+            .withItems(ITEMS)
+            .build();
+
+    @Test
+    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom default client")
+    void testDefaultTimeoutConfiguration() {
+        PayFurlClient payFurlClient = new PayFurlClient.Builder()
+                .build();
+
+        then(payFurlClient.getTimeout()).isEqualTo(TimeUnit.SECONDS.toMillis(60));
+    }
+
+    @Test
+    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom timeout client")
+    void testCustomTimeoutConfiguration() {
+        long smallTimeoutMs = 40;
+        PayFurlClient payFurlClient = new PayFurlClient.Builder()
+                .withHttpClientConfiguration((config) -> config.timeout(smallTimeoutMs))
+                .build();
+
+        then(payFurlClient.getTimeout()).isEqualTo(smallTimeoutMs);
+    }
+
+    @Nested
+    class FailFlow {
+
+        @Test
+        @DisplayName("Given PayFurlClient configuration with small timeout When create API is called Then throw client's timeout error")
+        void testSmallTimeoutConfigurationToCauseException() {
+            // given
+            PayFurlClient lowTimeoutPayFurlClient = new PayFurlClient.Builder()
+                    .withHttpClientConfiguration((config) -> config.timeout(10))
+                    .withEnvironment(TestConfigProvider.getEnvironmentWithFallback())
+                    .withSecretKey(TestConfigProvider.getSecretKeyWithFallback())
+                    .build();
+
+            ChargeApi lowTimeoutChargeApi = lowTimeoutPayFurlClient.getChargeApi();
+
+            NewChargeCardLeastCost newChargeCardLeastCost = new NewChargeCardLeastCost.Builder()
+                    .withAmount(BigDecimal.valueOf(258))
+                    .withPaymentInformation(SAMPLE_PAYMENT_INFORMATION)
+                    .withOrder(SAMPLE_ORDER)
+                    .withAddress(SAMPLE_ADDRESS)
+                    .withMetadata(METADATA)
+                    .build();
+
+            // when
+            Throwable throwable = catchThrowable(() -> lowTimeoutChargeApi.createWithCardLeastCost(newChargeCardLeastCost));
+
+            // then
+            then(throwable).isInstanceOf(ApiException.class)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new ApiException(ApiError.buildTimeoutError()));
+        }
+    }
+}

--- a/src/test/java/com/payfurl/payfurlsdk/TimeoutTest.java
+++ b/src/test/java/com/payfurl/payfurlsdk/TimeoutTest.java
@@ -65,7 +65,7 @@ public class TimeoutTest {
             .build();
 
     @Test
-    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom default client")
+    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return default timeout")
     void testDefaultTimeoutConfiguration() {
         PayFurlClient payFurlClient = new PayFurlClient.Builder()
                 .build();
@@ -74,7 +74,7 @@ public class TimeoutTest {
     }
 
     @Test
-    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom timeout client")
+    @DisplayName("Given PayFurlClient configuration When create OkHttClient is called Then return custom timeout")
     void testCustomTimeoutConfiguration() {
         long smallTimeoutMs = 40;
         PayFurlClient payFurlClient = new PayFurlClient.Builder()

--- a/src/test/java/com/payfurl/payfurlsdk/api/support/WebhookToolsTest.java
+++ b/src/test/java/com/payfurl/payfurlsdk/api/support/WebhookToolsTest.java
@@ -2,18 +2,11 @@ package com.payfurl.payfurlsdk.api.support;
 
 import com.payfurl.payfurlsdk.models.WebhookTransaction;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.BDDAssertions.then;
 
 class WebhookToolsTest {
     private static final String TEST_WEBHOOK_SIGNATURE_KEY = "dCM6l9ngZMJXVappk73yS607k1K7byfyzTTdToaKMa8=";
@@ -21,6 +14,7 @@ class WebhookToolsTest {
     private static final String TEST_PAYFURL_REQUEST_HEADER_SIGNATURE = "rDYP2MxMKvvmoV2KrbOi4pnelHnVJoFYdBegvCK7IQk=";
 
     @Test
+    @DisplayName("Given prefilled webhook When deserialize Then deserialize transaction")
     void testDeserializeTransactionWithValidEntity() {
         WebhookTransaction webhookTransaction = WebhookTools.deserializeTransaction(TEST_SAMPLE_REQUEST_BODY, TEST_PAYFURL_REQUEST_HEADER_SIGNATURE, TEST_WEBHOOK_SIGNATURE_KEY);
 
@@ -28,6 +22,7 @@ class WebhookToolsTest {
     }
 
     @Test
+    @DisplayName("Given prefilled webhook When request body is incorrect Then throw exception")
     void testDeserializeTransactionWithInvalidEntity() {
         Throwable throwable = catchThrowable(() -> WebhookTools.deserializeTransaction(StringUtils.EMPTY, "InvalidSignature", TEST_WEBHOOK_SIGNATURE_KEY));
 

--- a/src/test/java/com/payfurl/payfurlsdk/apitesting/ChargeApiTest.java
+++ b/src/test/java/com/payfurl/payfurlsdk/apitesting/ChargeApiTest.java
@@ -59,7 +59,7 @@ public class ChargeApiTest {
             .withPostalCode("5006")
             .withCountry("Australia")
             .build();
-    private static final List<ProductItem> Items = Arrays.asList(new ProductItem.Builder()
+    private static final List<ProductItem> ITEMS = Arrays.asList(new ProductItem.Builder()
                     .withAmount(BigDecimal.valueOf(123))
                     .withDescription("First item")
                     .withQuantity(1)
@@ -75,11 +75,11 @@ public class ChargeApiTest {
                     .withProductCode("PC15678")
                     .withUnitOfMeasure("kg")
                     .build());
-    private static final Order SAMPLE_ORER = new Order.Builder()
+    private static final Order SAMPLE_ORDER = new Order.Builder()
             .withOrderNumber("12345ON")
             .withDutyAmount(BigDecimal.valueOf(1))
             .withFreightAmount(BigDecimal.valueOf(2))
-            .withItems(Items)
+            .withItems(ITEMS)
             .build();
 
     private ChargeApi chargeApi;
@@ -109,7 +109,7 @@ public class ChargeApiTest {
                     .withProviderId(TestConfigProvider.getProviderId())
                     .withPaymentInformation(SAMPLE_PAYMENT_INFORMATION)
                     .withAddress(SAMPLE_ADDRESS)
-                    .withOrder(SAMPLE_ORER)
+                    .withOrder(SAMPLE_ORDER)
                     .withMetadata(METADATA)
                     .build();
 
@@ -131,7 +131,7 @@ public class ChargeApiTest {
                     .withProviderId(TestConfigProvider.getProviderId())
                     .withPaymentInformation(SAMPLE_PAYMENT_INFORMATION)
                     .withAddress(SAMPLE_ADDRESS)
-                    .withOrder(SAMPLE_ORER)
+                    .withOrder(SAMPLE_ORDER)
                     .withWebhookConfig(new WebhookConfig.Builder()
                             .withUrl("https://webhook.site/1da8cac9-fef5-47bf-a276-81856f73d7ca")
                             .withAuthorization("Basic user:password")
@@ -156,7 +156,7 @@ public class ChargeApiTest {
                     .withProviderId(TestConfigProvider.getProviderId())
                     .withPaymentInformation(SAMPLE_FAILED_PAYMENT_INFORMATION)
                     .withAddress(SAMPLE_ADDRESS)
-                    .withOrder(SAMPLE_ORER)
+                    .withOrder(SAMPLE_ORDER)
                     .build();
 
             Throwable throwable = catchThrowable(() -> chargeApi.createWithCard(newChargeCardRequest));
@@ -181,7 +181,7 @@ public class ChargeApiTest {
             NewChargeCardLeastCost newChargeCardLeastCost = new NewChargeCardLeastCost.Builder()
                     .withAmount(BigDecimal.valueOf(258))
                     .withPaymentInformation(SAMPLE_PAYMENT_INFORMATION)
-                    .withOrder(SAMPLE_ORER)
+                    .withOrder(SAMPLE_ORDER)
                     .withAddress(SAMPLE_ADDRESS)
                     .withMetadata(METADATA)
                     .build();
@@ -249,46 +249,6 @@ public class ChargeApiTest {
             // then
             then(chargeData).isNotNull();
             then(chargeData.status).isEqualTo(SUCCESS_MARKER);
-        }
-    }
-
-    @Nested
-    class FailFlow {
-
-        @Test
-        @DisplayName("Given PayFurlClient configuration with small timeout When create API is called Then throw client's timeout error")
-        void testSmallTimeoutConfigurationToCauseException() {
-            // given
-            PayFurlClient lowTimeoutPayFurlClient = new PayFurlClient.Builder()
-                    .withHttpClientConfiguration((config) -> config.timeout(10))
-                    .withEnvironment(TestConfigProvider.getEnvironmentWithFallback())
-                    .withSecretKey(TestConfigProvider.getSecretKeyWithFallback())
-                    .build();
-
-            ChargeApi lowTimeoutChargeApi = lowTimeoutPayFurlClient.getChargeApi();
-
-            NewChargeCardLeastCost newChargeCardLeastCost = new NewChargeCardLeastCost.Builder()
-                    .withAmount(BigDecimal.valueOf(258))
-                    .withPaymentInformation(SAMPLE_PAYMENT_INFORMATION)
-                    .withOrder(SAMPLE_ORER)
-                    .withAddress(SAMPLE_ADDRESS)
-                    .withMetadata(METADATA)
-                    .build();
-
-            // when
-            Throwable throwable = catchThrowable(() -> lowTimeoutChargeApi.createWithCardLeastCost(newChargeCardLeastCost));
-
-            // then
-            then(throwable).isInstanceOf(ApiException.class)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new ApiException(new ApiError.Builder()
-                            .withCode(ErrorCode.UnknownError)
-                            .withMessage("timeout")
-                            .withResource(null)
-                            .withIsRetryable(false)
-                            .withType("https://docs.payfurl.com/errorcodes.html#1")
-                            .withHttpCode(500)
-                            .build()));
         }
     }
 }


### PR DESCRIPTION
1) Add correct logic for an optional timeout in milliseconds:

- By default 60 sec in milliseconds

```java
PayFurlClient payFurlClient = new PayFurlClient.Builder().build();

then(payFurlClient.getTimeout()).isEqualTo(TimeUnit.SECONDS.toMillis(60));
```

- Custom timeout in milliseconds

```java
long smallTimeoutMs = 40;
PayFurlClient payFurlClient = new PayFurlClient.Builder()
                .withHttpClientConfiguration((config) -> config.timeout(smallTimeoutMs))
                .build();

then(payFurlClient.getTimeout()).isEqualTo(smallTimeoutMs);
```

2) Add correct handling timeout exception (InterruptedIOException thrown in case of timeout, this is the base class for SocketTimeoutException), as result was `UnknownError` for timeout, now `TimeoutError`:

`catch (InterruptedIOException interruptedIOException)`

3) Add tests for configuration timeout & API test for testing in the real-life call:

![image](https://user-images.githubusercontent.com/113937834/232041165-7649e797-e7d2-446f-b4ff-245762943ef2.png)

4) Small enhancements for existing tests